### PR TITLE
CSS fixes related to scrollbars appearing when they shouldn't

### DIFF
--- a/frontend/static/css/editor.css
+++ b/frontend/static/css/editor.css
@@ -23,7 +23,7 @@ body {
 }
 
 #tabs {
-  width: 99%;
+  box-sizing: border-box;
   height: 80%;
 }
 
@@ -36,6 +36,7 @@ body {
 .firepad {
   display: inline;
   height: auto;
+  width: 99%;
   position: absolute;
   bottom: 0;
   top: 35px;

--- a/frontend/static/css/editor.css
+++ b/frontend/static/css/editor.css
@@ -11,7 +11,7 @@ body {
   float: left;
   width: 200px;
   overflow-y: scroll;
-  max-height: 100vh;
+  max-height: 100%;
   font-family: "Roboto", "Arial", sans-serif;
   font-size: 13px;
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/cedar/11)
<!-- Reviewable:end -->
